### PR TITLE
Refactor Home and Venta styles

### DIFF
--- a/components/styles.js
+++ b/components/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-export default StyleSheet.create({
+const styles = StyleSheet.create({
   // Contenedor general
   container: {
     flex: 1,
@@ -361,4 +361,275 @@ export default StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
   },
+  editButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
 });
+
+const ingredientStyles = StyleSheet.create({
+  dialog: {
+    marginHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+  },
+  modalHeaderMargin: {
+    marginBottom: 12,
+  },
+  modalActionsBetween: {
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+  },
+  modalActionsEnd: {
+    justifyContent: 'flex-end',
+    paddingHorizontal: 8,
+  },
+  rowCenter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  cardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardInfo: {
+    flex: 1,
+    marginRight: 12,
+  },
+  ingredientName: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  ingredientUnit: {
+    fontSize: 14,
+    color: '#555',
+    marginBottom: 4,
+  },
+  ingredientPrice: {
+    fontSize: 14,
+    color: '#555',
+  },
+  saveButton: {
+    marginLeft: 8,
+    backgroundColor: '#007bff',
+  },
+  deleteLabel: {
+    color: '#dc3545',
+    marginLeft: 4,
+  },
+  mb12: {
+    marginBottom: 12,
+  },
+  mb16: {
+    marginBottom: 16,
+  },
+  mb4: {
+    marginBottom: 4,
+  },
+  cardPadding: {
+    padding: 16,
+  },
+  separator: {
+    height: 12,
+  },
+  labelGray: {
+    color: '#666',
+  },
+});
+
+const tortaStyles = StyleSheet.create({
+  dialog: {
+    marginHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+  },
+  modalHeaderMargin: {
+    marginBottom: 12,
+  },
+  mb12: {
+    marginBottom: 12,
+  },
+  imageContainer: {
+    backgroundColor: '#f9f9f9',
+    borderRadius: 8,
+    padding: 12,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  previewImage: {
+    width: '100%',
+    height: 140,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  imageActions: {
+    flexDirection: 'row',
+    width: '60%',
+    justifyContent: 'space-between',
+  },
+  actionButton: {
+    alignItems: 'center',
+  },
+  actionTextBlue: {
+    color: '#007bff',
+    fontSize: 12,
+  },
+  actionTextDelete: {
+    color: '#dc3545',
+    fontSize: 12,
+  },
+  uploadText: {
+    color: '#007bff',
+    marginTop: 4,
+  },
+  modalActionsBetween: {
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+  },
+  rowCenter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  deleteLabel: {
+    color: '#dc3545',
+    marginLeft: 4,
+  },
+  viewRecipeButton: {
+    marginRight: 8,
+    backgroundColor: '#6c757d',
+  },
+  primaryButton: {
+    backgroundColor: '#007bff',
+  },
+  cardMargin: {
+    marginBottom: 10,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  flex1: {
+    flex: 1,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 6,
+  },
+  whiteText: {
+    color: '#fff',
+  },
+});
+
+const homeStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  circle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#ccc',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 8,
+  },
+  circleText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  name: {
+    flex: 1,
+    fontSize: 14,
+    color: '#333',
+  },
+  info: {
+    fontSize: 12,
+    color: '#007bff',
+    marginLeft: 8,
+  },
+});
+
+const ventaStyles = StyleSheet.create({
+  card: {
+    marginHorizontal: 16,
+    marginVertical: 8,
+    borderRadius: 12,
+    elevation: 2,
+    backgroundColor: '#fff',
+    overflow: 'hidden',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+  },
+  badgeCount: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#007bff10',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  badgeText: {
+    color: '#007bff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#666',
+  },
+  sum: {
+    color: '#28a745',
+    fontWeight: '700',
+  },
+  detailContainer: {
+    maxHeight: 200,
+    borderTopWidth: 1,
+    borderColor: '#eee',
+  },
+  detailScroll: {
+    paddingHorizontal: 16,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 6,
+  },
+  detailDate: {
+    fontSize: 12,
+    color: '#555',
+  },
+  detailPrice: {
+    fontSize: 12,
+    color: '#28a745',
+    fontWeight: '500',
+  },
+});
+
+export { ingredientStyles, tortaStyles, homeStyles, ventaStyles };
+export default styles;

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -8,12 +8,11 @@ import {
   Modal,
   Pressable,
   Alert,
-  FlatList,
-  StyleSheet
+  FlatList
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { useFocusEffect } from '@react-navigation/native';
-import styles from '../components/styles';
+import styles, { homeStyles } from '../components/styles';
 import {
   obtenerCantidadVentas,
   obtenerGanancias,
@@ -192,14 +191,14 @@ export default function HomeScreen({ navigation }) {
           </View>
           {top3.length > 0 ? (
             top3.map((t, i) => (
-              <View key={i} style={localStyles.row}>
-                <View style={localStyles.circle}>
-                  <Text style={localStyles.circleText}>{i + 1}</Text>
+              <View key={i} style={homeStyles.row}>
+                <View style={homeStyles.circle}>
+                  <Text style={homeStyles.circleText}>{i + 1}</Text>
                 </View>
-                <Text style={localStyles.name} numberOfLines={1} ellipsizeMode="tail">
+                <Text style={homeStyles.name} numberOfLines={1} ellipsizeMode="tail">
                   {t.name}
                 </Text>
-                <Text style={localStyles.info}>
+                <Text style={homeStyles.info}>
                   {t.count} ventas ({t.percent}%)
                 </Text>
               </View>
@@ -262,33 +261,3 @@ export default function HomeScreen({ navigation }) {
   );
 }
 
-const localStyles = StyleSheet.create({
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8
-  },
-  circle: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: '#ccc',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 8
-  },
-  circleText: {
-    color: '#fff',
-    fontWeight: 'bold'
-  },
-  name: {
-    flex: 1,
-    fontSize: 14,
-    color: '#333'
-  },
-  info: {
-    fontSize: 12,
-    color: '#007bff',
-    marginLeft: 8
-  }
-});

--- a/screens/IngredientScreen.js
+++ b/screens/IngredientScreen.js
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { Card, Portal, Dialog, TextInput, Button } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
-import styles from '../components/styles';
+import styles, { ingredientStyles as ingStyles } from '../components/styles';
 import {
   fetchIngredientes,
   agregarIngrediente,
@@ -18,7 +18,7 @@ import {
 } from '../controllers/IngredientController';
 
 const FieldLabel = ({ children }) => (
-  <Text style={[styles.inputLabel, { marginBottom: 4 }]}>{children}</Text>
+  <Text style={[styles.inputLabel, ingStyles.mb4]}>{children}</Text>
 );
 
 const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSave, onDelete }) => {
@@ -53,9 +53,9 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
       <Dialog
         visible={visible}
         onDismiss={onDismiss}
-        style={{ marginHorizontal: 16, borderRadius: 8, backgroundColor: '#fff' }}
+        style={ingStyles.dialog}
       >
-        <View style={[styles.modalHeader, { marginBottom: 12 }]}>
+        <View style={[styles.modalHeader, ingStyles.modalHeaderMargin]}>
           <Text style={styles.modalTitle}>Editar Ingrediente</Text>
           <Pressable onPress={onDismiss} hitSlop={10}>
             <Ionicons name="close-circle" size={24} color="#666" />
@@ -68,7 +68,7 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
             placeholder="Ej. Harina"
             value={local.nombre}
             onChangeText={t => handleChange('nombre', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Unidad de medida</FieldLabel>
@@ -77,7 +77,7 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
             placeholder="Ej. Gramos"
             value={local.unidad_Medida}
             onChangeText={t => handleChange('unidad_Medida', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Tamaño paquete</FieldLabel>
@@ -87,7 +87,7 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
             keyboardType="numeric"
             value={local.tamano_Paquete}
             onChangeText={t => handleChange('tamano_Paquete', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Precio / paquete</FieldLabel>
@@ -97,7 +97,7 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
             keyboardType="numeric"
             value={local.costo}
             onChangeText={t => handleChange('costo', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Stock disponible</FieldLabel>
@@ -107,20 +107,20 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
             keyboardType="numeric"
             value={local.CantidadStock}
             onChangeText={t => handleChange('CantidadStock', t)}
-            style={[styles.input, { marginBottom: 16 }]}
+            style={[styles.input, ingStyles.mb16]}
           />
         </Dialog.Content>
 
-        <Dialog.Actions style={{ justifyContent: 'space-between', paddingHorizontal: 8 }}>
+        <Dialog.Actions style={ingStyles.modalActionsBetween}>
           {/* Botón Eliminar */}
-          <TouchableOpacity onPress={() => onDelete(local.id)} style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <TouchableOpacity onPress={() => onDelete(local.id)} style={ingStyles.rowCenter}>
             <Ionicons name="trash-outline" size={20} color="#dc3545" />
-            <Text style={{ color: '#dc3545', marginLeft: 4 }}>Eliminar</Text>
+            <Text style={ingStyles.deleteLabel}>Eliminar</Text>
           </TouchableOpacity>
 
           {/* Cancelar / Guardar */}
-          <View style={{ flexDirection: 'row' }}>
-            <Button mode="text" onPress={onDismiss} labelStyle={{ color: '#666' }}>
+          <View style={ingStyles.row}>
+            <Button mode="text" onPress={onDismiss} labelStyle={ingStyles.labelGray}>
               Cancelar
             </Button>
             <Button
@@ -133,7 +133,7 @@ const EditIngredienteModal = React.memo(({ visible, onDismiss, ingrediente, onSa
                 costo: parseFloat(local.costo),
                 CantidadStock: parseInt(local.CantidadStock, 10),
               })}
-              style={{ marginLeft: 8, backgroundColor: '#007bff' }}
+              style={ingStyles.saveButton}
             >
               Guardar
             </Button>
@@ -168,9 +168,9 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
       <Dialog
         visible={visible}
         onDismiss={onDismiss}
-        style={{ marginHorizontal: 16, borderRadius: 8, backgroundColor: '#fff' }}
+        style={ingStyles.dialog}
       >
-        <View style={[styles.modalHeader, { marginBottom: 12 }]}>
+        <View style={[styles.modalHeader, ingStyles.modalHeaderMargin]}>
           <Text style={styles.modalTitle}>Agregar Ingrediente</Text>
           <Pressable onPress={onDismiss} hitSlop={10}>
             <Ionicons name="close-circle" size={24} color="#666" />
@@ -183,7 +183,7 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
             placeholder="Ej. Azúcar"
             value={local.nombre}
             onChangeText={t => handleChange('nombre', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Unidad de medida</FieldLabel>
@@ -192,7 +192,7 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
             placeholder="Ej. Kilos"
             value={local.unidad_Medida}
             onChangeText={t => handleChange('unidad_Medida', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Tamaño paquete</FieldLabel>
@@ -202,7 +202,7 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
             keyboardType="numeric"
             value={local.tamano_Paquete}
             onChangeText={t => handleChange('tamano_Paquete', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Precio / paquete</FieldLabel>
@@ -212,7 +212,7 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
             keyboardType="numeric"
             value={local.costo}
             onChangeText={t => handleChange('costo', t)}
-            style={[styles.input, { marginBottom: 12 }]}
+            style={[styles.input, ingStyles.mb12]}
           />
 
           <FieldLabel>Stock disponible</FieldLabel>
@@ -222,12 +222,12 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
             keyboardType="numeric"
             value={local.CantidadStock}
             onChangeText={t => handleChange('CantidadStock', t)}
-            style={[styles.input, { marginBottom: 16 }]}
+            style={[styles.input, ingStyles.mb16]}
           />
         </Dialog.Content>
 
-        <Dialog.Actions style={{ justifyContent: 'flex-end', paddingHorizontal: 8 }}>
-          <Button mode="text" onPress={onDismiss} labelStyle={{ color: '#666' }}>
+        <Dialog.Actions style={ingStyles.modalActionsEnd}>
+          <Button mode="text" onPress={onDismiss} labelStyle={ingStyles.labelGray}>
             Cancelar
           </Button>
           <Button
@@ -239,7 +239,7 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
               costo: parseFloat(local.costo),
               CantidadStock: parseInt(local.CantidadStock, 10),
             })}
-            style={{ marginLeft: 8, backgroundColor: '#007bff' }}
+            style={ingStyles.saveButton}
           >
             Guardar
           </Button>
@@ -299,11 +299,11 @@ export default function IngredientScreen() {
         onChangeText={setSearch}
         mode="outlined"
         left={<TextInput.Icon name="magnify" />}
-        style={[styles.searchInput, { marginBottom: 16 }]}
+        style={[styles.searchInput, ingStyles.mb16]}
       />
 
  <TouchableOpacity
-        style={[styles.botonAgregarIngrediente, { marginBottom: 12 }]}
+        style={[styles.botonAgregarIngrediente, ingStyles.mb12]}
         onPress={() => setAddVisible(true)}
       >
        
@@ -313,21 +313,21 @@ export default function IngredientScreen() {
   data={filtered}
   keyExtractor={i => i.id.toString()}
   renderItem={({ item }) => (
-    <Card style={[styles.card, { padding: 16 }]}>
-      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+    <Card style={[styles.card, ingStyles.cardPadding]}>
+      <View style={ingStyles.cardRow}>
         {/* Datos */}
-        <View style={{ flex: 1, marginRight: 12 }}>
+        <View style={ingStyles.cardInfo}>
           {/* Nombre */}
-          <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 4 }}>
+          <Text style={ingStyles.ingredientName}>
             {item.nombre}
           </Text>
           {/* Unidad + Tamaño */}
-          <Text style={{ fontSize: 14, color: '#555', marginBottom: 4 }}>
+          <Text style={ingStyles.ingredientUnit}>
             <Ionicons name="cube-outline" size={14} color="#555" />{' '}
             {item.tamano_Paquete} {item.unidad_Medida}
           </Text>
           {/* Precio + Stock */}
-          <Text style={{ fontSize: 14, color: '#555' }}>
+          <Text style={ingStyles.ingredientPrice}>
             <Ionicons name="pricetag-outline" size={14} color="#555" />{' '}
             ${parseFloat(item.costo).toFixed(2)}{'   '}
             <Ionicons name="layers-outline" size={14} color="#555" />{' '}
@@ -344,7 +344,7 @@ export default function IngredientScreen() {
       </View>
     </Card>
   )}
-  ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+  ItemSeparatorComponent={() => <View style={ingStyles.separator} />}
   contentContainerStyle={{ paddingBottom: 32 }}
 />
 

--- a/screens/TortasScreen.js
+++ b/screens/TortasScreen.js
@@ -6,7 +6,7 @@ import { Card, Portal, Dialog, TextInput, Button } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
-import styles from '../components/styles';
+import styles, { tortaStyles as tStyles } from '../components/styles';
 import {
   fetchTortas,
   agregarTorta,
@@ -18,14 +18,7 @@ const BASE_URL = 'http://149.50.131.253/api';
 const PRIMARY_BLUE = '#007bff';
 
 const FieldLabel = ({ children }) => (
-  <Text style={[styles.inputLabel, {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 6
-  }]}>
-    {children}
-  </Text>
+  <Text style={[styles.inputLabel, tStyles.fieldLabel]}>{children}</Text>
 );
 
 const EditTortaModal = React.memo(({ visible, onDismiss, torta, onSave, onDelete }) => {
@@ -71,9 +64,9 @@ const EditTortaModal = React.memo(({ visible, onDismiss, torta, onSave, onDelete
       <Dialog
         visible={visible}
         onDismiss={onDismiss}
-        style={{ marginHorizontal: 16, borderRadius: 8, backgroundColor: '#fff' }}
+        style={tStyles.dialog}
       >
-        <View style={[styles.modalHeader, { marginBottom: 12 }]}>
+        <View style={[styles.modalHeader, tStyles.modalHeaderMargin]}>
           <Text style={styles.modalTitle}>Editar Torta</Text>
           <Pressable onPress={onDismiss} hitSlop={10}>
             <Ionicons name="close-circle" size={24} color="#666" />
@@ -87,7 +80,7 @@ const EditTortaModal = React.memo(({ visible, onDismiss, torta, onSave, onDelete
             placeholder="Ej. Torta de chocolate"
             value={local.nombre_torta}
             onChangeText={t => handleChange('nombre_torta', t)}
-            style={[styles.input, { marginBottom: 12, backgroundColor: '#fff' }]}
+            style={[styles.input, tStyles.mb12, { backgroundColor: '#fff' }]}
           />
           <FieldLabel>Descripción</FieldLabel>
           <TextInput
@@ -96,55 +89,49 @@ const EditTortaModal = React.memo(({ visible, onDismiss, torta, onSave, onDelete
             multiline
             value={local.descripcion_torta}
             onChangeText={t => handleChange('descripcion_torta', t)}
-            style={[styles.input, { marginBottom: 12, minHeight: 80, backgroundColor: '#fff' }]}
+            style={[styles.input, { minHeight: 80, backgroundColor: '#fff' }, tStyles.mb12]}
           />
           <FieldLabel>Imagen</FieldLabel>
-          <View style={{
-            backgroundColor: '#f9f9f9',
-            borderRadius: 8,
-            padding: 12,
-            alignItems: 'center',
-            marginBottom: 16
-          }}>
+          <View style={tStyles.imageContainer}>
             {local.imagen ? (
               <>
                 <Image
                   source={{ uri: local.imagen }}
-                  style={{ width: '100%', height: 140, borderRadius: 8, marginBottom: 8 }}
+                  style={tStyles.previewImage}
                 />
-                <View style={{ flexDirection: 'row', width: '60%', justifyContent: 'space-between' }}>
-                  <TouchableOpacity onPress={pickImage} style={{ alignItems: 'center' }}>
+                <View style={tStyles.imageActions}>
+                  <TouchableOpacity onPress={pickImage} style={tStyles.actionButton}>
                     <Ionicons name="image-outline" size={24} color={PRIMARY_BLUE} />
-                    <Text style={{ color: PRIMARY_BLUE, fontSize: 12 }}>Cambiar</Text>
+                    <Text style={tStyles.actionTextBlue}>Cambiar</Text>
                   </TouchableOpacity>
-                  <TouchableOpacity onPress={removeImage} style={{ alignItems: 'center' }}>
+                  <TouchableOpacity onPress={removeImage} style={tStyles.actionButton}>
                     <Ionicons name="trash-outline" size={24} color="#dc3545" />
-                    <Text style={{ color: '#dc3545', fontSize: 12 }}>Eliminar</Text>
+                    <Text style={tStyles.actionTextDelete}>Eliminar</Text>
                   </TouchableOpacity>
                 </View>
               </>
             ) : (
-              <TouchableOpacity onPress={pickImage} style={{ alignItems: 'center' }}>
+              <TouchableOpacity onPress={pickImage} style={tStyles.actionButton}>
                 <Ionicons name="image-outline" size={32} color={PRIMARY_BLUE} />
-                <Text style={{ color: PRIMARY_BLUE, marginTop: 4 }}>Subir imagen</Text>
+                <Text style={tStyles.uploadText}>Subir imagen</Text>
               </TouchableOpacity>
             )}
           </View>
         </Dialog.Content>
 
-        <Dialog.Actions style={{ justifyContent: 'space-between', paddingHorizontal: 8 }}>
-          <TouchableOpacity onPress={() => onDelete(local.ID_TORTA)} style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Dialog.Actions style={tStyles.modalActionsBetween}>
+          <TouchableOpacity onPress={() => onDelete(local.ID_TORTA)} style={tStyles.rowCenter}>
             <Ionicons name="trash-outline" size={20} color="#dc3545" />
-            <Text style={{ color: '#dc3545', marginLeft: 4 }}>Eliminar</Text>
+            <Text style={tStyles.deleteLabel}>Eliminar</Text>
           </TouchableOpacity>
-          <View style={{ flexDirection: 'row' }}>
-            <Button onPress={handleVerReceta} style={{ marginRight: 8, backgroundColor: '#6c757d' }}>
-              <Text style={{ color: '#fff' }}>Ver Receta</Text>
+          <View style={tStyles.row}>
+            <Button onPress={handleVerReceta} style={tStyles.viewRecipeButton}>
+              <Text style={tStyles.whiteText}>Ver Receta</Text>
             </Button>
             <Button
               mode="contained"
               onPress={() => onSave(local)}
-              style={{ backgroundColor: PRIMARY_BLUE }}
+              style={tStyles.primaryButton}
               labelStyle={{ color: '#fff' }}
             >
               Guardar
@@ -228,10 +215,10 @@ export default function TortaScreen() {
         value={search}
         onChangeText={setSearch}
         mode="outlined"
-        style={[styles.searchInput, { marginBottom: 12 }]}
+        style={[styles.searchInput, tStyles.mb12]}
       />
       <TouchableOpacity
-        style={[styles.botonAgregarIngrediente, { marginBottom: 12 }]}
+        style={[styles.botonAgregarIngrediente, tStyles.mb12]}
         onPress={() => setAddVisible(true)}
       >
         <Text style={styles.botonAgregarTexto}>Agregar Torta</Text>
@@ -242,10 +229,10 @@ export default function TortaScreen() {
         keyExtractor={item => item.ID_TORTA.toString()}
         contentContainerStyle={{ paddingBottom: 24 }}
         renderItem={({ item }) => (
-          <Card style={[styles.card, { marginBottom: 10 }]}>
+          <Card style={[styles.card, tStyles.cardMargin]}>
             <Card.Content>
-              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-                <View style={{ flex: 1 }}>
+              <View style={tStyles.cardRow}>
+                <View style={tStyles.flex1}>
                   <Text style={styles.cardTitle}>{item.nombre_torta}</Text>
                   <Text style={styles.cardText}>{item.descripcion_torta}</Text>
                 </View>

--- a/screens/VentaScreen.js
+++ b/screens/VentaScreen.js
@@ -4,7 +4,6 @@ import {
   View,
   Text,
   FlatList,
-  StyleSheet,
   ActivityIndicator,
   Alert,
   TouchableOpacity,
@@ -12,7 +11,7 @@ import {
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { Card, Divider } from 'react-native-paper';
-import styles from '../components/styles';
+import styles, { ventaStyles } from '../components/styles';
 import { obtenerVentas } from '../controllers/VentaController';
 
 export default function SalesByCakeScreen() {
@@ -61,37 +60,37 @@ export default function SalesByCakeScreen() {
   const renderItem = ({ item }) => {
     const isOpen = expanded === item.name;
     return (
-      <Card style={local.card}>
+      <Card style={ventaStyles.card}>
         <TouchableOpacity activeOpacity={0.7} onPress={() => toggle(item.name)}>
-          <View style={local.headerRow}>
-            <View style={local.badgeCount}>
-              <Text style={local.badgeText}>{item.count}</Text>
+          <View style={ventaStyles.headerRow}>
+            <View style={ventaStyles.badgeCount}>
+              <Text style={ventaStyles.badgeText}>{item.count}</Text>
             </View>
-            <View style={local.info}>
-              <Text style={local.name} numberOfLines={1} ellipsizeMode="tail">
+            <View style={ventaStyles.info}>
+              <Text style={ventaStyles.name} numberOfLines={1} ellipsizeMode="tail">
                 {item.name}
               </Text>
-              <Text style={local.subtitle}>
-                Ingresos: <Text style={local.sum}>${item.sum}</Text>
+              <Text style={ventaStyles.subtitle}>
+                Ingresos: <Text style={ventaStyles.sum}>${item.sum}</Text>
               </Text>
             </View>
           </View>
         </TouchableOpacity>
 
         {isOpen && (
-          <View style={local.detailContainer}>
+          <View style={ventaStyles.detailContainer}>
             <ScrollView
-              style={local.detailScroll}
+              style={ventaStyles.detailScroll}
               showsVerticalScrollIndicator
               nestedScrollEnabled
             >
               {item.items.map((v, idx) => (
                 <View key={idx}>
-                  <View style={local.detailRow}>
-                    <Text style={local.detailDate} numberOfLines={1} ellipsizeMode="tail">
+                  <View style={ventaStyles.detailRow}>
+                    <Text style={ventaStyles.detailDate} numberOfLines={1} ellipsizeMode="tail">
                       {new Date(v.fecha_venta).toLocaleDateString()}
                     </Text>
-                    <Text style={local.detailPrice}>
+                    <Text style={ventaStyles.detailPrice}>
                       ${parseFloat(v.precio_torta).toFixed(2)}
                     </Text>
                   </View>
@@ -122,71 +121,3 @@ export default function SalesByCakeScreen() {
   );
 }
 
-const local = StyleSheet.create({
-  card: {
-    marginHorizontal: 16,
-    marginVertical: 8,
-    borderRadius: 12,
-    elevation: 2,
-    backgroundColor: '#fff',
-    overflow: 'hidden',
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 16,
-  },
-  badgeCount: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: '#007bff10',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 12,
-  },
-  badgeText: {
-    color: '#007bff',
-    fontSize: 16,
-    fontWeight: '700',
-  },
-  info: {
-    flex: 1,
-  },
-  name: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#666',
-  },
-  sum: {
-    color: '#28a745',
-    fontWeight: '700',
-  },
-  detailContainer: {
-    maxHeight: 200,
-    borderTopWidth: 1,
-    borderColor: '#eee',
-  },
-  detailScroll: {
-    paddingHorizontal: 16,
-  },
-  detailRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingVertical: 6,
-  },
-  detailDate: {
-    fontSize: 12,
-    color: '#555',
-  },
-  detailPrice: {
-    fontSize: 12,
-    color: '#28a745',
-    fontWeight: '500',
-  },
-});


### PR DESCRIPTION
## Summary
- centralize HomeScreen and VentaScreen style objects in `components/styles.js`
- update HomeScreen to consume `homeStyles`
- update VentaScreen to consume `ventaStyles`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f7d74c884832b88739a99c84c75ba