### PR TITLE
Fix: oculta menú y encabezado en Login/Register

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -58,12 +58,20 @@ const Navigation = () => {
         <Drawer.Screen
           name="Login"
           component={LoginScreen}
-          options={{ drawerItemStyle: { height: 0 } }}
+          options={{
+            drawerItemStyle: { height: 0 },
+            headerShown: false,
+            swipeEnabled: false,
+          }}
         />
         <Drawer.Screen
           name="Register"
           component={RegisterScreen}
-          options={{ drawerItemStyle: { height: 0 } }}
+          options={{
+            drawerItemStyle: { height: 0 },
+            headerShown: false,
+            swipeEnabled: false,
+          }}
         />
 
       </Drawer.Navigator>


### PR DESCRIPTION
## Summary
- hide hamburger menu and header for Login and Register screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e253c44832bb5c28169f4966309