### PR TITLE
Add quick ingredient creation from recipe

### DIFF
--- a/screens/IngredientScreen.js
+++ b/screens/IngredientScreen.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useRoute, useNavigation } from '@react-navigation/native';
 import {
   View,
   Text,
@@ -250,6 +251,8 @@ const AddIngredienteModal = React.memo(({ visible, onDismiss, onSave }) => {
 });
 
 export default function IngredientScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
   const [ingredientes, setIngredientes] = useState([]);
   const [addVisible, setAddVisible] = useState(false);
   const [editVisible, setEditVisible] = useState(false);
@@ -266,6 +269,14 @@ export default function IngredientScreen() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // Si navega desde Recetas con el flag openAdd, mostrar el modal al abrir
+  useEffect(() => {
+    if (route.params?.openAdd) {
+      setAddVisible(true);
+      navigation.setParams({ openAdd: false });
+    }
+  }, [route.params]);
 
   const filtered = ingredientes.filter(i =>
     i.nombre.toLowerCase().includes(search.toLowerCase())

--- a/screens/RecetaScreen.js
+++ b/screens/RecetaScreen.js
@@ -241,6 +241,12 @@ const handleVerTorta = () => {
     }
   };
 
+  // Navegar a la vista de ingredientes y abrir el modal de creación
+  const handleCrearIngrediente = () => {
+    setIngredienteModalVisible(false);
+    navigation.navigate('Ingredientes', { openAdd: true });
+  };
+
   const handleEliminarIngrediente = async (ID_INGREDIENTE) => {
     try {
       setFormData(prev => ({
@@ -534,6 +540,12 @@ const handleVerTorta = () => {
                 keyboardType="numeric"
                 editable={!loading}
               />
+              <Pressable
+                onPress={handleCrearIngrediente}
+                style={{ alignSelf: 'flex-end', marginVertical: 8 }}
+              >
+                <Text style={styles.seccionLink}>Crear nuevo ingrediente</Text>
+              </Pressable>
               <View style={styles.modalBotones}>
                 <Pressable style={[styles.boton, { marginHorizontal: 8 }]} onPress={() => setIngredienteModalVisible(false)}>
                   <Text style={styles.botonTexto}>Cancelar</Text>


### PR DESCRIPTION
## Summary
- enable navigation to ingredient screen from recipe ingredient modal
- auto-open add ingredient modal when navigating from recipes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e815e1b30832b806b2be05e688ffb