### PR TITLE
Add empty sales notice and alphabetize ingredient list

### DIFF
--- a/screens/RecetaScreen.js
+++ b/screens/RecetaScreen.js
@@ -97,9 +97,9 @@ const handleVerTorta = () => {
     return precioEncontrado ? `$${precioEncontrado.costo_total}` : 'Precio no disponible';
   };
 
-  const ingredientesDisponibles = ingredientes.filter(
-    ing => !formData.ingredientes.some(i => i.ID_INGREDIENTE === ing.id)
-  );
+  const ingredientesDisponibles = ingredientes
+    .filter(ing => !formData.ingredientes.some(i => i.ID_INGREDIENTE === ing.id))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre));
 
   const handleSaveReceta = async () => {
     if (!formData.nombre_torta.trim() && !formData.ID_TORTA) {

--- a/screens/VentaScreen.js
+++ b/screens/VentaScreen.js
@@ -9,6 +9,7 @@ import {
   TouchableOpacity,
   ScrollView
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { Card, Divider } from 'react-native-paper';
 import styles, { ventaStyles } from '../components/styles';
@@ -106,6 +107,15 @@ export default function SalesByCakeScreen() {
 
   if (loading) {
     return <ActivityIndicator size="large" color="#007bff" style={{ marginTop: 40 }} />;
+  }
+
+  if (data.length === 0) {
+    return (
+      <View style={[styles.container, { justifyContent: 'center', alignItems: 'center' }]}>
+        <Ionicons name="cart-outline" size={72} color="#ccc" style={{ marginBottom: 16 }} />
+        <Text style={styles.heroSubtitle}>No hay ventas registradas</Text>
+      </View>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- notify user when there are no sales
- sort ingredient dropdown alphabetically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e8ab3a86c832b99607621079ddcee