### PR TITLE
Maintain TurboModules for Expo SDK 53

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# CostOSmart App
+
+This project uses **Expo SDK 53** with React Native 0.79 and Hermes. The
+`PlatformConstants` module is provided via TurboModules.
+
+If TurboModules are disabled (for example by setting `"turboModules": false` in
+`app.json`) the app will crash on startup with an error similar to:
+
+```
+TurboModuleRegistry.getEnforcing(...): 'PlatformConstants' could not be found
+```
+
+To avoid this error, keep TurboModules enabled (do not set
+`"turboModules": false`). When changing native configuration or upgrading
+packages, rebuild the development client so that all TurboModules are bundled:
+
+```bash
+npm run build:android
+```
+
+This command runs `expo prebuild` and then `expo run:android`.
+
+It is also recommended to keep dependencies up to date. The project includes
+recent versions of `react-native-paper` and `react-native-image-picker` which
+support Expo's new architecture.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "prebuild": "expo prebuild",
+    "build:android": "expo prebuild && expo run:android"
   },
   "dependencies": {
     "expo-secure-store": "^12.1.0",
@@ -25,8 +27,8 @@
     "react-native-chart-kit": "^6.12.0",
     "react-native-dropdown-picker": "^5.4.6",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-image-picker": "^7.2.3",
-    "react-native-paper": "^5.11.6",
+    "react-native-image-picker": "^7.2.4",
+    "react-native-paper": "^5.14.4",
     "react-native-picker-select": "^9.0.1",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",


### PR DESCRIPTION
## Summary
- document how to keep TurboModules enabled
- add prebuild/build scripts
- update image picker and paper deps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687058924e08832b977b86291e29ba37