### PR TITLE
Centralize API configuration

### DIFF
--- a/controllers/IngredientController.js
+++ b/controllers/IngredientController.js
@@ -1,10 +1,9 @@
-import axios from 'axios';
 import UserController, { sendAuthenticatedRequest } from './UserController';
-import { API_URL } from '../config';
+import api from '../src/services/api';
 
 export const fetchIngredientes = async () => {
   try {
-    const data = await sendAuthenticatedRequest(`${API_URL}/ingredientes`);
+    const data = await sendAuthenticatedRequest('/ingredientes');
     
     // Asegúrate de que data.ingredientes sea un array
     if (data.success && Array.isArray(data.ingredientes)) {
@@ -19,7 +18,7 @@ export const fetchIngredientes = async () => {
 
 export const fetchIngredientesMenosStock = async () => {
   try {
-    const data = await sendAuthenticatedRequest(`${API_URL}/ingredientes/menosstock`);
+    const data = await sendAuthenticatedRequest('/ingredientes/menosstock');
     return data;
   } catch (error) {
     return [];
@@ -29,8 +28,8 @@ export const fetchIngredientesMenosStock = async () => {
 export const agregarIngrediente = async (ingrediente) => {
   try {
     const token = await UserController.getToken();
-    const { data } = await axios.post(
-      `${API_URL}/ingredientes`,
+    const { data } = await api.post(
+      '/ingredientes',
       ingrediente,
       {
         headers: {
@@ -48,8 +47,8 @@ export const agregarIngrediente = async (ingrediente) => {
 export const editarIngrediente = async (ingrediente) => {
   try {
     const token = await UserController.getToken();
-    const { data } = await axios.put(
-      `${API_URL}/ingredientes/${ingrediente.id}`,
+    const { data } = await api.put(
+      `/ingredientes/${ingrediente.id}`,
       ingrediente,
       {
         headers: {
@@ -67,7 +66,7 @@ export const editarIngrediente = async (ingrediente) => {
 export const borrarIngrediente = async (id) => {
   try {
     const token = await UserController.getToken();
-    const { status, data } = await axios.delete(`${API_URL}/ingredientes/${id}`, {
+    const { status, data } = await api.delete(`/ingredientes/${id}`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/controllers/ListaPreciosController.js
+++ b/controllers/ListaPreciosController.js
@@ -1,9 +1,8 @@
 import { sendAuthenticatedRequest, UserController } from './UserController';
-import { API_URL } from '../config';
 
 export const fetchListaPrecios = async () => {
   try {
-    const data = await sendAuthenticatedRequest(`${API_URL}/lista_precios`);
+    const data = await sendAuthenticatedRequest('/lista_precios');
     return data;
   } catch (error) {
     return [];

--- a/controllers/RecetaController.js
+++ b/controllers/RecetaController.js
@@ -1,10 +1,9 @@
 import { sendAuthenticatedRequest, UserController } from './UserController';
-import axios from 'axios';
-import { API_URL } from '../config';
+import api from '../src/services/api';
 
 export const fetchRecetas = async () => {
   try {
-    const response = await sendAuthenticatedRequest(`${API_URL}/recetas`);
+    const response = await sendAuthenticatedRequest('/recetas');
 
     // Procesar la respuesta agrupada del backend
     return response.map(receta => ({
@@ -22,7 +21,7 @@ export const fetchRecetas = async () => {
 export const agregarReceta = async (recetaBase) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.post(`${API_URL}/tortas`, recetaBase, {
+    const response = await api.post('/tortas', recetaBase, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
@@ -37,8 +36,8 @@ export const agregarReceta = async (recetaBase) => {
 export const agregarIngrediente = async (ID_TORTA, ID_INGREDIENTE, cantidad) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.post(
-      `${API_URL}/recetas/nueva-relacion`,
+    const response = await api.post(
+      '/recetas/nueva-relacion',
       { ID_TORTA, ID_INGREDIENTE, cantidad },
       { headers: { Authorization: `Bearer ${token}` } }
     );
@@ -72,8 +71,8 @@ export const editarCantidadIngrediente = async (ID_TORTA, ID_INGREDIENTE, cantid
   try {
     const token = await UserController.getToken();
 
-    const response = await axios.put(
-      `${API_URL}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
+    const response = await api.put(
+      `/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
       { total_cantidad: cantidad },
       { headers: { Authorization: `Bearer ${token}` } }
     );
@@ -93,8 +92,8 @@ export const editarCantidadIngrediente = async (ID_TORTA, ID_INGREDIENTE, cantid
 export const eliminarIngrediente = async (ID_TORTA, ID_INGREDIENTE) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.delete(
-      `${API_URL}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
+    const response = await api.delete(
+      `/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
       { headers: { 'Authorization': `Bearer ${token}` } }
     );
 
@@ -113,8 +112,8 @@ export const eliminarIngrediente = async (ID_TORTA, ID_INGREDIENTE) => {
 export const borrarReceta = async (ID_TORTA) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.delete(
-      `${API_URL}/recetas/${ID_TORTA}`,
+    const response = await api.delete(
+      `/recetas/${ID_TORTA}`,
       { headers: { 'Authorization': `Bearer ${token}` } }
     );
 

--- a/controllers/TortaController.js
+++ b/controllers/TortaController.js
@@ -1,10 +1,9 @@
 import { sendAuthenticatedRequest, UserController } from './UserController';
-import axios from 'axios';
-import { API_URL } from '../config';
+import api from '../src/services/api';
 
 export const fetchTortas = async () => {
   try {
-    const data = await sendAuthenticatedRequest(`${API_URL}/tortas`);
+    const data = await sendAuthenticatedRequest('/tortas');
     return data;
   } catch (error) {
     return [];
@@ -14,7 +13,7 @@ export const fetchTortas = async () => {
 export const agregarTorta = async (tortaData) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.post(`${API_URL}/tortas`, tortaData, {
+    const response = await api.post('/tortas', tortaData, {
       headers: {
         'Content-Type': 'multipart/form-data',
         Authorization: `Bearer ${token}`,
@@ -32,7 +31,7 @@ export const agregarTorta = async (tortaData) => {
 
 export const editarTorta = async (idTorta, formData) => {
   try {
-    const { data } = await axios.put(`${API_URL}/tortas/${idTorta}`, formData, {
+    const { data } = await api.put(`/tortas/${idTorta}`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
     return data;
@@ -44,7 +43,7 @@ export const editarTorta = async (idTorta, formData) => {
 export const borrarTorta = async (id) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.delete(`${API_URL}/tortas/${id}`, {
+    const response = await api.delete(`/tortas/${id}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
 

--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import api from '../src/services/api';
 import * as SecureStore from 'expo-secure-store';
-import { API_URL } from '../config';
 
 let authToken = null;
 
@@ -11,7 +10,7 @@ export const sendAuthenticatedRequest = async (url, config = {}) => {
       throw new Error('No se ha obtenido un token de autenticación');
     }
 
-    const response = await axios({
+    const response = await api({
       url,
       headers: { 'Authorization': `Bearer ${token}` },
       method: 'get',
@@ -27,7 +26,7 @@ export const sendAuthenticatedRequest = async (url, config = {}) => {
 export const UserController = {
   registerUser: async (userData) => {
     try {
-      const { data } = await axios.post(`${API_URL}/users/register`, userData);
+      const { data } = await api.post('/users/register', userData);
       return data;
     } catch (error) {
       throw error;
@@ -36,7 +35,7 @@ export const UserController = {
 
   loginUser: async (email, contrasena) => {
     try {
-      const { data } = await axios.post(`${API_URL}/login`, { email, contrasena });
+      const { data } = await api.post('/login', { email, contrasena });
       await storeToken(data.token);
       return data;
     } catch (error) {

--- a/controllers/VentaController.js
+++ b/controllers/VentaController.js
@@ -1,12 +1,11 @@
-import axios from 'axios';
+import api from '../src/services/api';
 import UserController, { sendAuthenticatedRequest } from './UserController';
-import { API_URL } from '../config';
 
 // Controlador de ventas
 export const Ventas = async () => {
   try {
-    const ventas = await sendAuthenticatedRequest(`${API_URL}/ventas`);
-    const tortas = await sendAuthenticatedRequest(`${API_URL}/tortas`);
+    const ventas = await sendAuthenticatedRequest('/ventas');
+    const tortas = await sendAuthenticatedRequest('/tortas');
 
     if (!ventas || !tortas) {
       throw new Error('Error al obtener las listas de ventas o tortas');
@@ -27,7 +26,7 @@ export const Ventas = async () => {
 };
 export const obtenerVentas = async () => {
   try {
-      const ventas = await sendAuthenticatedRequest(`${API_URL}/ventas`);
+      const ventas = await sendAuthenticatedRequest('/ventas');
 
       return ventas;
   } catch (error) {
@@ -38,7 +37,7 @@ export const obtenerVentas = async () => {
 export const registrarVenta = async (idTorta) => {
   try {
     const token = await UserController.getToken();
-    const response = await axios.post(`${API_URL}/ventas`, { id_torta: idTorta }, {
+    const response = await api.post('/ventas', { id_torta: idTorta }, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -51,7 +50,7 @@ export const registrarVenta = async (idTorta) => {
 
 export const obtenerCantidadVentas = async () => {
     try {
-      const response = await sendAuthenticatedRequest(`${API_URL}/ventas/cantidad`);
+      const response = await sendAuthenticatedRequest('/ventas/cantidad');
       const cantidadVentas = response?.cantidadVentas;
 
       if (cantidadVentas === undefined) {
@@ -66,7 +65,7 @@ export const obtenerCantidadVentas = async () => {
 
 export const obtenerGanancias = async () => {
   try {
-    const response = await sendAuthenticatedRequest(`${API_URL}/ventas/ganancias`);
+    const response = await sendAuthenticatedRequest('/ventas/ganancias');
     const ganancias = response?.ganancias;
     if (ganancias === undefined) {
       throw new Error('La propiedad "ganancias" no está definida en la respuesta');
@@ -80,7 +79,7 @@ export const obtenerGanancias = async () => {
 
 export const obtenerCantidadVentasSemanales = async () => {
   try {
-    const response = await sendAuthenticatedRequest(`${API_URL}/ventas/cantidad-semana`);
+    const response = await sendAuthenticatedRequest('/ventas/cantidad-semana');
     const cantidadVentasSemana = response?.cantidadVentasSemana;
 
     if (cantidadVentasSemana === undefined) {
@@ -95,7 +94,7 @@ export const obtenerCantidadVentasSemanales = async () => {
 
 export const obtenerPorcentajeVentas = async () => {
   try {
-    const response = await sendAuthenticatedRequest(`${API_URL}/ventas/porcentaje-ventas`);
+    const response = await sendAuthenticatedRequest('/ventas/porcentaje-ventas');
     const porcentajeVentas = response?.porcentajeCambio;
 
     if (porcentajeVentas === undefined) {

--- a/screens/RecetaScreen.js
+++ b/screens/RecetaScreen.js
@@ -17,7 +17,7 @@ import {
 import { Picker } from '@react-native-picker/picker';
 import { Ionicons } from '@expo/vector-icons';
 import styles from '../components/styles';
-import { API_URL } from '../config';
+import { API_URL } from '../src/services/api';
 import AddIngredienteModal from '../components/AddIngredienteModal';
 import IngredienteItem from '../components/IngredienteItem';
 import useRecetas from '../hooks/useRecetas';

--- a/screens/TortasScreen.js
+++ b/screens/TortasScreen.js
@@ -13,8 +13,7 @@ import {
   editarTorta,
   borrarTorta
 } from '../controllers/TortaController';
-
-const BASE_URL = 'http://149.50.131.253/api';
+import { API_URL } from '../src/services/api';
 const PRIMARY_BLUE = '#007bff';
 
 const FieldLabel = ({ children }) => (
@@ -31,7 +30,7 @@ const EditTortaModal = React.memo(({ visible, onDismiss, torta, onSave, onDelete
         ID_TORTA: torta.ID_TORTA,
         nombre_torta: torta.nombre_torta,
         descripcion_torta: torta.descripcion_torta,
-        imagen: torta.imagen ? `${BASE_URL}/${torta.imagen}` : '',
+        imagen: torta.imagen ? `${API_URL}/${torta.imagen}` : '',
       });
     }
   }, [visible, torta]);
@@ -202,7 +201,7 @@ export default function TortaScreen() {
     f.append('ID_TORTA', d.ID_TORTA);
     f.append('nombre_torta', d.nombre_torta);
     f.append('descripcion_torta', d.descripcion_torta);
-    if (d.imagen && !d.imagen.startsWith(BASE_URL)) {
+    if (d.imagen && !d.imagen.startsWith(API_URL)) {
       const name = d.imagen.split('/').pop(), type = name.split('.').pop();
       f.append('imagen', { uri: d.imagen, name, type: `image/${type}` });
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,10 @@
+import axios from 'axios';
 import Constants from 'expo-constants';
 
 export const API_URL = Constants.expoConfig?.extra?.API_URL;
 
+const api = axios.create({
+  baseURL: API_URL,
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- introduce `src/services/api.js` with Axios instance and API_URL export
- refactor controllers to use the shared Axios instance
- update Tortas and Receta screens to import API_URL
- remove outdated `config.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68743ec1b684832b85346dcc794575dc