### PR TITLE
Add Jest configuration and basic tests

### DIFF
--- a/__tests__/controllers/IngredientController.test.js
+++ b/__tests__/controllers/IngredientController.test.js
@@ -1,0 +1,21 @@
+import { fetchIngredientes } from '../../controllers/IngredientController';
+import { sendAuthenticatedRequest } from '../../controllers/UserController';
+
+jest.mock('../../controllers/UserController', () => ({
+  sendAuthenticatedRequest: jest.fn()
+}));
+
+describe('fetchIngredientes', () => {
+  it('returns ingredientes when request succeeds', async () => {
+    const ingredientes = [{ id: 1, nombre: 'Azucar' }];
+    sendAuthenticatedRequest.mockResolvedValue({ success: true, ingredientes });
+    const result = await fetchIngredientes();
+    expect(result).toEqual(ingredientes);
+  });
+
+  it('returns empty array when request fails', async () => {
+    sendAuthenticatedRequest.mockRejectedValue(new Error('network'));
+    const result = await fetchIngredientes();
+    expect(result).toEqual([]);
+  });
+});

--- a/__tests__/controllers/VentaController.test.js
+++ b/__tests__/controllers/VentaController.test.js
@@ -1,0 +1,21 @@
+import { obtenerVentas } from '../../controllers/VentaController';
+import { sendAuthenticatedRequest } from '../../controllers/UserController';
+
+jest.mock('../../controllers/UserController', () => ({
+  sendAuthenticatedRequest: jest.fn()
+}));
+
+describe('obtenerVentas', () => {
+  it('returns ventas on success', async () => {
+    const ventas = [{ ID_TORTA: 1 }];
+    sendAuthenticatedRequest.mockResolvedValue(ventas);
+    const result = await obtenerVentas();
+    expect(result).toEqual(ventas);
+  });
+
+  it('throws when request fails', async () => {
+    const error = new Error('fail');
+    sendAuthenticatedRequest.mockRejectedValue(error);
+    await expect(obtenerVentas()).rejects.toBe(error);
+  });
+});

--- a/__tests__/screens/HomeScreen.test.js
+++ b/__tests__/screens/HomeScreen.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import HomeScreen from '../../screens/HomeScreen';
+import * as VentaController from '../../controllers/VentaController';
+import * as IngredienteController from '../../controllers/IngredientController';
+import * as TortaController from '../../controllers/TortaController';
+
+jest.mock('../../controllers/VentaController');
+jest.mock('../../controllers/IngredientController');
+jest.mock('../../controllers/TortaController');
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(fn => fn()),
+}));
+
+describe('HomeScreen', () => {
+  beforeEach(() => {
+    VentaController.obtenerCantidadVentas.mockResolvedValue(2);
+    VentaController.obtenerGanancias.mockResolvedValue(100);
+    VentaController.obtenerVentas.mockResolvedValue([]);
+    IngredienteController.fetchIngredientesMenosStock.mockResolvedValue([]);
+    TortaController.fetchTortas.mockResolvedValue([{ ID_TORTA: 1, nombre_torta: 'A' }]);
+  });
+
+  it('renders title', async () => {
+    const { getByText } = render(<HomeScreen navigation={{ navigate: jest.fn() }} />);
+    await waitFor(() => getByText('Panel de Control'));
+    expect(getByText('Panel de Control')).toBeTruthy();
+  });
+
+  it('opens modal when new sale button pressed', async () => {
+    const { getByText, queryByText } = render(<HomeScreen navigation={{ navigate: jest.fn() }} />);
+    await waitFor(() => getByText('Generar Nueva Venta'));
+    fireEvent.press(getByText('Generar Nueva Venta'));
+    await waitFor(() => expect(queryByText('Registrar Venta')).toBeTruthy());
+  });
+});

--- a/__tests__/screens/TortaScreen.test.js
+++ b/__tests__/screens/TortaScreen.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import TortaScreen from '../../screens/TortasScreen';
+import * as TortaController from '../../controllers/TortaController';
+
+jest.mock('../../controllers/TortaController');
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useRoute: () => ({ params: {} })
+}));
+
+
+describe('TortaScreen', () => {
+  beforeEach(() => {
+    TortaController.fetchTortas.mockResolvedValue([
+      { ID_TORTA: 1, nombre_torta: 'Choc', descripcion_torta: 'desc' }
+    ]);
+  });
+
+  it('renders list of tortas', async () => {
+    const { getByText } = render(<TortaScreen />);
+    await waitFor(() => getByText('Choc'));
+    expect(getByText('Choc')).toBeTruthy();
+  });
+
+  it('opens edit modal when Editar pressed', async () => {
+    const { getByText } = render(<TortaScreen />);
+    await waitFor(() => getByText('Editar'));
+    fireEvent.press(getByText('Editar'));
+    await waitFor(() => getByText('Editar Torta'));
+    expect(getByText('Editar Torta')).toBeTruthy();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'react-native',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|expo|@expo)/)'
+  ]
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+import 'react-native-gesture-handler/jestSetup';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild && expo run:android"
+    ,"test": "jest"
   },
   "dependencies": {
     "expo": "^53.0.9",
@@ -44,7 +45,9 @@
     "metro-transform-worker": "^0.82.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.24.0"
+    "@babel/core": "^7.24.0",
+    "jest": "^29.7.0",
+    "@testing-library/react-native": "^12.1.5"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add jest and testing library to dev dependencies
- configure Jest
- write unit tests for controller functions
- add initial integration tests for HomeScreen and TortaScreen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744537bf3c832b89caffc114650171