### PR TITLE
Improve UX for auth screens

### DIFF
--- a/components/styles.js
+++ b/components/styles.js
@@ -520,6 +520,13 @@ const tortaStyles = StyleSheet.create({
   flex1: {
     flex: 1,
   },
+  listThumbnail: {
+    width: 60,
+    height: 60,
+    borderRadius: 8,
+    marginRight: 12,
+    backgroundColor: '#eee',
+  },
   fieldLabel: {
     fontSize: 14,
     fontWeight: '600',

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import { View, Text, Pressable, Alert, ActivityIndicator } from 'react-native';
+import { TextInput } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import UserController from '../controllers/UserController';
 import styles from '../components/styles';
@@ -7,13 +8,21 @@ import styles from '../components/styles';
 const LoginScreen = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [contrasena, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleLogin = async () => {
+    if (!email.trim() || !contrasena.trim()) {
+      Alert.alert('Error', 'Completa email y contraseña');
+      return;
+    }
+    setLoading(true);
     try {
-      const response = await UserController.loginUser(email, contrasena);
+      await UserController.loginUser(email, contrasena);
       navigation.navigate('HomeScreen');
     } catch (error) {
       Alert.alert('Error', error.message);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -24,28 +33,36 @@ const LoginScreen = ({ navigation }) => {
           Bienvenido
         </Text>
 
-        <Text style={[styles.label, { marginBottom: 4 }]}>Correo electrónico</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 16 }]}
+          mode="outlined"
+          label="Correo electrónico"
           placeholder="usuario@ejemplo.com"
           keyboardType="email-address"
           autoCapitalize="none"
           value={email}
           onChangeText={setEmail}
+          style={[styles.input, { marginBottom: 16, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-email"
+          testID="login-email"
         />
 
-        <Text style={[styles.label, { marginBottom: 4 }]}>Contraseña</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 24 }]}
+          mode="outlined"
+          label="Contraseña"
           placeholder="••••••••"
           secureTextEntry
           value={contrasena}
           onChangeText={setPassword}
+          style={[styles.input, { marginBottom: 24, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-contrasena"
+          testID="login-password"
         />
 
         {/* Botón mejorado */}
         <Pressable
           onPress={handleLogin}
+          disabled={loading}
+          accessibilityRole="button"
           style={({ pressed }) => [
             styles.botonPrimario,
             {
@@ -55,22 +72,30 @@ const LoginScreen = ({ navigation }) => {
               width: '100%',
               paddingVertical: 14,
               borderRadius: 12,
-              elevation: 4,             // Android
-              shadowColor: '#000',      // iOS
+              elevation: 4,
+              shadowColor: '#000',
               shadowOffset: { width: 0, height: 2 },
               shadowOpacity: 0.25,
               shadowRadius: 3.84,
               opacity: pressed ? 0.8 : 1,
-            }
+            },
           ]}
         >
-          <Ionicons name="log-in-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
-          <Text style={styles.botonTexto}>Iniciar Sesión</Text>
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <>
+              <Ionicons name="log-in-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
+              <Text style={styles.botonTexto}>Iniciar Sesión</Text>
+            </>
+          )}
         </Pressable>
 
         <Pressable
           onPress={() => navigation.navigate('Register')}
           style={{ marginTop: 16, alignSelf: 'center' }}
+          accessibilityRole="link"
+          accessibilityLabel="registrarse"
         >
           <Text style={styles.seccionLink}>
             ¿No tienes una cuenta? Regístrate

--- a/screens/RegisterScreen.js
+++ b/screens/RegisterScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import { View, Text, Pressable, Alert, ActivityIndicator } from 'react-native';
+import { TextInput } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import UserController from '../controllers/UserController';
 import styles from '../components/styles';
@@ -9,12 +10,18 @@ const RegisterScreen = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [contrasena, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleRegister = async () => {
+    if (!nombre.trim() || !email.trim() || !contrasena.trim()) {
+      Alert.alert('Error', 'Completa todos los campos');
+      return;
+    }
     if (contrasena !== confirmPassword) {
       Alert.alert('Error', 'Las contraseñas no coinciden');
       return;
     }
+    setLoading(true);
     try {
       const userData = { nombre, email, contrasena };
       await UserController.registerUser(userData);
@@ -23,6 +30,8 @@ const RegisterScreen = ({ navigation }) => {
       ]);
     } catch (error) {
       Alert.alert('Error', 'No se pudo registrar el usuario');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -30,40 +39,54 @@ const RegisterScreen = ({ navigation }) => {
     <View style={[styles.container, { justifyContent: 'center', alignItems: 'center' }]}>
       <View style={[styles.card, { width: '90%', maxWidth: 400, padding: 24 }]}>
         <Text style={[styles.cardTitle, { fontSize: 24, textAlign: 'center', marginBottom: 16 }]}>Crear Cuenta</Text>
-        <Text style={[styles.label, { marginBottom: 4 }]}>Nombre</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 16 }]}
+          mode="outlined"
+          label="Nombre"
           placeholder="Tu nombre"
           value={nombre}
           onChangeText={setNombre}
+          style={[styles.input, { marginBottom: 16, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-nombre"
+          testID="register-name"
         />
-        <Text style={[styles.label, { marginBottom: 4 }]}>Correo electrónico</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 16 }]}
+          mode="outlined"
+          label="Correo electrónico"
           placeholder="usuario@ejemplo.com"
           keyboardType="email-address"
           autoCapitalize="none"
           value={email}
           onChangeText={setEmail}
+          style={[styles.input, { marginBottom: 16, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-email"
+          testID="register-email"
         />
-        <Text style={[styles.label, { marginBottom: 4 }]}>Contraseña</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 16 }]}
+          mode="outlined"
+          label="Contraseña"
           placeholder="••••••••"
           secureTextEntry
           value={contrasena}
           onChangeText={setPassword}
+          style={[styles.input, { marginBottom: 16, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-contrasena"
+          testID="register-password"
         />
-        <Text style={[styles.label, { marginBottom: 4 }]}>Confirmar contraseña</Text>
         <TextInput
-          style={[styles.input, { marginBottom: 24 }]}
+          mode="outlined"
+          label="Confirmar contraseña"
           placeholder="••••••••"
           secureTextEntry
           value={confirmPassword}
           onChangeText={setConfirmPassword}
+          style={[styles.input, { marginBottom: 24, backgroundColor: '#fff' }]}
+          accessibilityLabel="campo-confirmar"
+          testID="register-confirm"
         />
         <Pressable
           onPress={handleRegister}
+          disabled={loading}
+          accessibilityRole="button"
           style={({ pressed }) => [
             styles.botonPrimario,
             {
@@ -82,10 +105,21 @@ const RegisterScreen = ({ navigation }) => {
             },
           ]}
         >
-          <Ionicons name="person-add-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
-          <Text style={styles.botonTexto}>Registrarse</Text>
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <>
+              <Ionicons name="person-add-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
+              <Text style={styles.botonTexto}>Registrarse</Text>
+            </>
+          )}
         </Pressable>
-        <Pressable onPress={() => navigation.navigate('Login')} style={{ marginTop: 16, alignSelf: 'center' }}>
+        <Pressable
+          onPress={() => navigation.navigate('Login')}
+          style={{ marginTop: 16, alignSelf: 'center' }}
+          accessibilityRole="link"
+          accessibilityLabel="ir-a-login"
+        >
           <Text style={styles.seccionLink}>¿Ya tienes una cuenta? Inicia sesión</Text>
         </Pressable>
       </View>

--- a/screens/TortasScreen.js
+++ b/screens/TortasScreen.js
@@ -247,6 +247,14 @@ export default function TortaScreen() {
             <Card style={[styles.card, tStyles.cardMargin]}>
               <Card.Content>
                 <View style={tStyles.cardRow}>
+                  {item.imagen ? (
+                    <Image
+                      source={{ uri: `${API_URL}/${item.imagen}` }}
+                      style={tStyles.listThumbnail}
+                    />
+                  ) : (
+                    <View style={tStyles.listThumbnail} />
+                  )}
                   <View style={tStyles.flex1}>
                     <Text style={styles.cardTitle}>{item.nombre_torta}</Text>
                     <Text style={styles.cardText}>{item.descripcion_torta}</Text>


### PR DESCRIPTION
## Summary
- upgrade LoginScreen with outlined TextInput fields and loading indicator
- upgrade RegisterScreen with input validation and accessibility props
- display thumbnail images in Torta list
- add new `listThumbnail` style

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d1310f978832b812d56ca981b2483