### PR TITLE
Implement logout functionality

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -10,6 +10,7 @@ import IngredientScreen from '../screens/IngredientScreen';
 import TortasScreen from '../screens/TortasScreen';
 import RecetaScreen from '../screens/RecetaScreen';
 import VentaScreen from '../screens/VentaScreen';
+import UserController from '../controllers/UserController';
 
 const Drawer = createDrawerNavigator();
 
@@ -24,7 +25,8 @@ const Navigation = () => {
         { text: 'Cancelar', style: 'cancel' },
         {
           text: 'Cerrar sesión',
-          onPress: () => {
+          onPress: async () => {
+            await UserController.logout();
             navigation.reset({
               index: 0,
               routes: [{ name: 'Login' }],

--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -55,6 +55,11 @@ export const UserController = {
     authToken = storedToken;
     return storedToken;
   },
+
+  logout: async () => {
+    await SecureStore.deleteItemAsync('authToken');
+    authToken = null;
+  },
 };
 
 const storeToken = async (token) => {


### PR DESCRIPTION
## Summary
- add a logout method in `UserController` to clear the stored auth token
- import and invoke logout when the user selects "Cerrar sesión" in navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d2546af94832ba385095a5f39017f